### PR TITLE
Bump to v2.0.1 and return to 'Felix Callouts' name

### DIFF
--- a/Felix Callouts/Properties/AssemblyInfo.cs
+++ b/Felix Callouts/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("FelixsCallouts")]
+[assembly: AssemblyTitle("Felix Callouts")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("FelixsCallouts")]
+[assembly: AssemblyProduct("Felix Callouts")]
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.1")]
-[assembly: AssemblyFileVersion("2.0.0.1")]
+[assembly: AssemblyVersion("2.0.1")]
+[assembly: AssemblyFileVersion("2.0.1")]


### PR DESCRIPTION
I think the plugin should follow [SemanticVersioning](https://semver.org/) (which it will with this bump) and that the Felix Callouts name is a nice and fresh way to get rid of the programer-awkward `'s`.